### PR TITLE
Allow using SMTP without user or password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/app/tmp/*
+/app/webroot/files/case_files/*

--- a/app/Controller/Component/SendgridComponent.php
+++ b/app/Controller/Component/SendgridComponent.php
@@ -7,11 +7,6 @@ class SendgridComponent extends EmailComponent
 	
 	function sendGridEmail($from,$to,$subject,$message,$type,$fromname=NULL)
 	{
-		if(!defined('SMTP_PWORD') || SMTP_PWORD == "******") {
-			sendEmail($from,$to,$subject,$message,$type);
-			return true;
-		}
-		
 		App::import('helper', 'Format');
 		$frmtHlpr = new FormatHelper(new View(null));
 	
@@ -36,32 +31,49 @@ class SendgridComponent extends EmailComponent
 			$this->Email->from = $from;
 		}
 		$this->Email->sendAs = 'html';
-		
-		$this->Email->smtpOptions = array(
-					'port'=>SMTP_PORT,
-					'host' => SMTP_HOST,
-					'username'=>SMTP_UNAME,
-					'password'=>SMTP_PWORD,
-				);
-				
+
+		if(defined('SMTP_USER') && defined('SMTP_PWORD') && SMTP_PWORD !== "******") {
+			$email_array = array(
+				'port' => SMTP_PORT,
+				'host' => SMTP_HOST,
+				'username' => SMTP_UNAME,
+				'password' => SMTP_PWORD
+			);
+		}
+		else {
+			$email_array = array(
+				'port' => SMTP_PORT,
+				'host'=> SMTP_HOST
+			);
+		}
+		$this->Email->smtpOptions = $email_array;
+
 		$response = $this->Email->send($message);
 		return $response;
 	}
+
 	function sendgridsmtp($email){
-		
-		if(!defined('SMTP_PWORD') || SMTP_PWORD == "******") {
-			return true;
-		}
 		$email->replyTo = FROM_EMAIL;
-		$email->smtpOptions = array(
-			'port'=>SMTP_PORT,
-			'host' => SMTP_HOST,
-			'username'=>SMTP_UNAME,
-			'password'=>SMTP_PWORD,
-		);
+		if(defined('SMTP_USER') && defined('SMTP_PWORD') && SMTP_PWORD !== "******") {
+			$email_array = array(
+				'port' => SMTP_PORT,
+				'host' => SMTP_HOST,
+				'username' => SMTP_UNAME,
+				'password' => SMTP_PWORD
+			);
+		}
+		else {
+			$email_array = array(
+				'port' => SMTP_PORT,
+				'host'=> SMTP_HOST
+			);
+		}
+
+		$email->smtpOptions = $email_array;
 		$response = $email->send();
 		return $response;
 	}	
+
 	function sendEmail($from,$to,$subject,$message,$type)
 	{
             App::import('helper', 'Format');


### PR DESCRIPTION
I run an SMTP server that allows anything internal to the network to send emails without providing credentials. This change no longer relies on the PHP mail function instead continues to use the CakeEmail but does not define the username or password for the smtpOptions. This allows for using and SMTP server that does not require credentials to be used. In order to use this, in the constants.php file you should comment out (or remove) the define for SMTP_PWORD.

I also added a .gitignore file to ignore locations within the repo where files are modified/updated while running the service. The logs and file attachments do not need to be part of the repository.

We should change the database.php and constants.php files to be something like database.sample.php and constants.sample.php, then as part of install instructions, have users rename those files and modify them. Then we can .gitignore system-specific configurations.