### PR TITLE
Added sort by priority and sort by multiple conditions

### DIFF
--- a/app/Controller/EasycasesController.php
+++ b/app/Controller/EasycasesController.php
@@ -1053,7 +1053,7 @@ class EasycasesController extends AppController {
             $filterenabled =1;
         }
         // Order by
-        $sortby ='';
+        $sortby = [];
         $orderby = [];
         if(isset($_COOKIE['TASKSORT'])) {
             $sortby = (array) json_decode( $_COOKIE['TASKSORT'] );
@@ -1064,21 +1064,16 @@ class EasycasesController extends AppController {
             if($fieldName == 'title') {
                 $orderby[] = "LTRIM(Easycase.title) ".$fieldValue;
                 $caseTitle = strtolower($fieldValue);
-            }
-            if($fieldName == 'duedate' ) {
+            }elseif($fieldName == 'duedate' ) {
                 $caseDueDate = strtolower($fieldValue);
                 $orderby[] = "Easycase.due_date ".$fieldValue;
-            }
-            if($fieldName === 'caseno' ) {
+            }elseif($fieldName === 'caseno' ) {
                 $caseNum = strtolower($fieldValue);
                 $orderby[] = "Easycase.case_no ".$fieldValue;
-            }
-            if($fieldName == 'caseAt') {
+            }elseif($fieldName == 'caseAt') {
                 $caseAtsort = strtolower($fieldValue);
                 $orderby[] = "Assigned ".$fieldValue;
-            }
-            if($fieldName == 'priority') {
-                $caseAtsort = strtolower($fieldValue);
+            }elseif($fieldName == 'priority') {
                 $orderby[] = "Easycase.priority ".$fieldValue;
             }
         }
@@ -4697,26 +4692,32 @@ class EasycasesController extends AppController {
 
         $arr['mlstn'] = "All";
         // Task Sort order tagging
-        if(isset($_COOKIE['TASKSORTBY']) && $_COOKIE['TASKSORTBY'] !="") {
-            $tsortby = $_COOKIE['TASKSORTBY'];
-            $tsortorder = $_COOKIE['TASKSORTORDER'];
-            if($_COOKIE['TASKSORTBY']=='caseno') {
-                $tsortby = 'Task#';
-            }elseif($_COOKIE['TASKSORTBY']=='caseAt') {
-                $tsortby = 'Assigned to';
-            }elseif($_COOKIE['TASKSORTBY']=='duedate') {
+        $sortby = [];
+        if(isset($_COOKIE['TASKSORT'])) {
+            $sortby = (array) json_decode( $_COOKIE['TASKSORT'] );
+        }
+
+        foreach($sortby as $fieldName => $fieldValue)
+        {
+            if($fieldName == 'duedate'){
                 $tsortby = 'Due Date';
-            }else {
-                $tsortby = ucfirst($tsortby);
+            }elseif($fieldName == 'caseno'){
+                $tsortby = 'Task#';
+            }elseif($fieldName == 'caseAt'){
+                $tsortby = 'Assigned to';
+            }else{
+                $tsortby = ucfirst($fieldName);
             }
-            if($tsortorder=='DESC') {
+
+            if($fieldValue=='DESC') {
                 $sorticon = 'tsk_desc_icon';
             }else {
                 $sorticon = 'tsk_asc_icon';
             }
-            //$arr['tasksortby'] = "<div class='fl filter_opn' rel='tooltip' title='Sort by ".$tsortby.": ".$tsortorder."' onclick='openfilter_popup(1,\"dropdown_menu_sortby_filters\");'><span class='fl'>".$tsortby."</span><i class='fl ".$sorticon."'></i><a href='javascript:void(0);' onclick='common_reset_filter(\"taskorder\",\"\",this);' class='fr'>X</a></div>";
-            $arr['tasksortby'] = "<div class='fl filter_opn' rel='tooltip' style='position:relative;' title='Sort by ".$tsortby.": ".$tsortorder."' onclick='openfilter_popup(1,\"dropdown_menu_sortby_filters\");'>".$tsortby."<i class=' ".$sorticon."'></i><a href='javascript:void(0);' onclick='common_reset_filter(\"taskorder\",\"\",this);' class='fr' style='padding-left:20px;'>X</a></div>";
-        }
+
+            $arr['tasksortby'] .= "<div class='fl filter_opn' rel='tooltip' style='position:relative;' title='Sort by ".$tsortby.": ".$tsortorder."' onclick='openfilter_popup(1,\"dropdown_menu_sortby_filters\");'>".$tsortby."<i class=' ".$sorticon."'></i><a href='javascript:void(0);' onclick='common_reset_filter(\"taskorder\",\"\",this);' class='fr' style='padding-left:20px;'>X</a></div>";
+       }
+
         // Task Group by Tagging
         if(isset($_COOKIE['TASKGROUPBY']) && $_COOKIE['TASKGROUPBY'] !="") {
             $groupby = $_COOKIE['TASKGROUPBY'];

--- a/app/Controller/EasycasesController.php
+++ b/app/Controller/EasycasesController.php
@@ -1054,29 +1054,41 @@ class EasycasesController extends AppController {
         }
         // Order by
         $sortby ='';
-        if(isset($_COOKIE['TASKSORTBY'])) {
-            $sortby = $_COOKIE['TASKSORTBY'];
-            $sortorder = $_COOKIE['TASKSORTORDER'];
+        $orderby = [];
+        if(isset($_COOKIE['TASKSORT'])) {
+            $sortby = (array) json_decode( $_COOKIE['TASKSORT'] );
         }
-        if($sortby=='title') {
-            $orderby = "LTRIM(Easycase.title) ".$sortorder;
-            $caseTitle = strtolower($sortorder);
-        }elseif($sortby=='duedate') {
-            $caseDueDate = strtolower($sortorder);
-            $orderby = "Easycase.due_date ".$sortorder;
-        }elseif($sortby=='caseno') {
-            $caseNum = strtolower($sortorder);
-            $orderby = "Easycase.case_no ".$sortorder;
-        }elseif($sortby=='caseAt') {
-            $caseAtsort = strtolower($sortorder);
-            $orderby = "Assigned ".$sortorder;
-        }elseif($sortby=='priority') {
-            $caseAtsort = strtolower($sortorder);
-            $orderby = "Priority ".$sortorder;
-        }else {
-            $orderby = "Easycase.dt_created DESC";
+
+        foreach( $sortby as $fieldName => $fieldValue )
+        {
+            if($fieldName == 'title') {
+                $orderby[] = "LTRIM(Easycase.title) ".$fieldValue;
+                $caseTitle = strtolower($fieldValue);
+            }
+            if($fieldName == 'duedate' ) {
+                $caseDueDate = strtolower($fieldValue);
+                $orderby[] = "Easycase.due_date ".$fieldValue;
+            }
+            if($fieldName === 'caseno' ) {
+                $caseNum = strtolower($fieldValue);
+                $orderby[] = "Easycase.case_no ".$fieldValue;
+            }
+            if($fieldName == 'caseAt') {
+                $caseAtsort = strtolower($fieldValue);
+                $orderby[] = "Assigned ".$fieldValue;
+            }
+            if($fieldName == 'priority') {
+                $caseAtsort = strtolower($fieldValue);
+                $orderby[] = "Easycase.priority ".$fieldValue;
+            }
         }
-        $groupby  = '';
+
+        if(empty($orderby)){
+            $orderby[] = "Easycase.dt_created DESC";
+        }
+        $orderby = implode( ', ', $orderby );
+
+        $groupby = '';
         $gby='';
         if(isset($_COOKIE['TASKGROUPBY']) && $_COOKIE['TASKGROUPBY'] !='date') {
             setcookie('TASKSORTBY','',time()-3600,'/',DOMAIN_COOKIE,false,false);

--- a/app/Controller/EasycasesController.php
+++ b/app/Controller/EasycasesController.php
@@ -1070,6 +1070,9 @@ class EasycasesController extends AppController {
         }elseif($sortby=='caseAt') {
             $caseAtsort = strtolower($sortorder);
             $orderby = "Assigned ".$sortorder;
+        }elseif($sortby=='priority') {
+            $caseAtsort = strtolower($sortorder);
+            $orderby = "Priority ".$sortorder;
         }else {
             $orderby = "Easycase.dt_created DESC";
         }

--- a/app/View/Easycase/dashboard.ctp
+++ b/app/View/Easycase/dashboard.ctp
@@ -125,11 +125,11 @@
 		<button type="button" class="btn tsk-menu-sortgroup-btn flt-txt sortby_btn <?php if(isset($_COOKIE['TASKGROUPBY']) && ($_COOKIE['TASKGROUPBY']!='date')){?>disable-btn<?php }?> " onclick="openfilter_popup(0,'dropdown_menu_sortby_filters');" <?php if(isset($_COOKIE['TASKGROUPBY']) && ($_COOKIE['TASKGROUPBY']!='date')){?>disabled="disabled"<?php }?>>
 				<i class="icon_sortby_img"></i>Sort by<i class="icon-filter-right"></i>
 		</button>
-		<ul class="dropdown-menu" id="dropdown_menu_sortby_filters" style="position: absolute;">
+		<ul class="dropdown-menu sortby" id="dropdown_menu_sortby_filters" style="position: absolute;">
 			<li class="pop_arrow_new"></li>
 			<li>
 				<a href="javascript:jsVoid();" data-toggle="dropdown" onclick="ajaxSorting('title');">Title</a>
-				<a href="javascript:jsVoid();" onclick="ajaxMultiSorting('title');">+</a>
+                <a href="javascript:jsVoid();" onclick="ajaxMultiSorting('title');">+</a>
 			</li>
 			<li>
 				<a href="javascript:jsVoid();" data-toggle="dropdown" onclick="ajaxSorting('caseno');">Task#</a>

--- a/app/View/Easycase/dashboard.ctp
+++ b/app/View/Easycase/dashboard.ctp
@@ -116,7 +116,7 @@
 					<a href="javascript:jsVoid();" title="Priority" data-toggle="dropdown" onclick="groupby('priority');">Priority</a>
 				</li>
 				<li>
-					<a href="javascript:jsVoid();" title="Priority" data-toggle="dropdown" onclick="groupby('assignto');">Assigned to</a>
+					<a href="javascript:jsVoid();" title="Assigned to" data-toggle="dropdown" onclick="groupby('assignto');">Assigned to</a>
 				</li>
 			</ul>
 		</div>
@@ -128,20 +128,25 @@
 		<ul class="dropdown-menu" id="dropdown_menu_sortby_filters" style="position: absolute;">
 			<li class="pop_arrow_new"></li>
 			<li>
-				<a href="javascript:jsVoid();"  data-toggle="dropdown" onclick="ajaxSorting('title');">Title</a>
+				<a href="javascript:jsVoid();" data-toggle="dropdown" onclick="ajaxSorting('title');">Title</a>
+				<a href="javascript:jsVoid();" onclick="ajaxMultiSorting('title');">+</a>
 			</li>
 			<li>
-				<a href="javascript:jsVoid();"  data-toggle="dropdown" onclick="ajaxSorting('caseno');">Task#</a>
+				<a href="javascript:jsVoid();" data-toggle="dropdown" onclick="ajaxSorting('caseno');">Task#</a>
+                <a href="javascript:jsVoid();" onclick="ajaxMultiSorting('caseno');">+</a>
+            </li>
+			<li>
+				<a href="javascript:jsVoid();" data-toggle="dropdown" onclick="ajaxSorting('duedate');"> Due Date</a>
+                <a href="javascript:jsVoid();" onclick="ajaxMultiSorting('duedate');">+</a>
+            </li>
+			<li>
+				<a href="javascript:jsVoid();" data-toggle="dropdown" onclick="ajaxSorting('caseAt');">Assigned to</a>
+                <a href="javascript:jsVoid();" onclick="ajaxMultiSorting('caseAt');">+</a>
 			</li>
 			<li>
-				<a href="javascript:jsVoid();"  data-toggle="dropdown" onclick="ajaxSorting('duedate');"> Due Date</a>
-			</li>
-			<li>
-				<a href="javascript:jsVoid();"  data-toggle="dropdown" onclick="ajaxSorting('caseAt');">Assigned to</a>
-			</li>
-			<li>
-				<a href="javascript:jsVoid();"  data-toggle="dropdown" onclick="ajaxSorting('priority');">Priority</a>
-			</li>
+				<a href="javascript:jsVoid();" data-toggle="dropdown" onclick="ajaxSorting('priority');">Priority</a>
+                <a href="javascript:jsVoid();" onclick="ajaxMultiSorting('priority');">+</a>
+            </li>
 
 		</ul>
 	</div>

--- a/app/View/Easycase/dashboard.ctp
+++ b/app/View/Easycase/dashboard.ctp
@@ -139,6 +139,9 @@
 			<li>
 				<a href="javascript:jsVoid();"  data-toggle="dropdown" onclick="ajaxSorting('caseAt');">Assigned to</a>
 			</li>
+			<li>
+				<a href="javascript:jsVoid();"  data-toggle="dropdown" onclick="ajaxSorting('priority');">Priority</a>
+			</li>
 
 		</ul>
 	</div>

--- a/app/webroot/css/style_inner.css
+++ b/app/webroot/css/style_inner.css
@@ -1,4 +1,4 @@
-/* 
+/*
 Author: Start Bootstrap - http://startbootstrap.com
 'SB Admin' HTML Template by Start Bootstrap
 
@@ -862,7 +862,7 @@ td.file_pdr a.file_name_ipad{max-width:460px;white-space:nowrap;text-overflow:el
 .task-type-cnt{margin: 6px;color: #397196;font-size: 11px;font-weight: bold;line-height: 0.6;padding: 3px;text-align: center;}
 
 /*Tab*/
-	
+
 @media (max-width:1030px) {	.ipad_txt{display:none}}
 @media (max-width:800px) {
 	.w-736{width:486px}
@@ -2279,7 +2279,7 @@ table.col-lg-12.ajx-srch-tbl tr.nohover:hover{background:#fff;color:#333; cursor
 	.kanbanview-filter #dropdown_menu_priority_div{left:-121px;}
 	.kanbanview-filter #dropdown_menu_types_div{left:-168px;}
 	.kanbanview-filter #dropdown_menu_status_div{left:-122px;}*/
-	
+
 	
 	
 /* Kanban view Menu filters */
@@ -2750,7 +2750,7 @@ li.dropdown.alerts-dropdown.help_a a{cursor:pointer}
 	border:1px solid #D3D3D3;
 	color:#C5C0B0;
 	display:none;
-	list-style:none;	
+	list-style:none;
 	left: -7px;
     margin-top: 3px;
     padding: 4px;
@@ -3164,3 +3164,16 @@ td.ml_title_wd{width:300px;}
 
 .edit_mile{background:url(../img/edit_ic2.png) no-repeat 0px 0px transparent; height:19px;width:23px;margin:3px -14px 0px 10px;cursor:pointer;opacity:0.3}
 .kbhead:hover .edit_mile{opacity:1}
+
+.dropdown-menu.sortby {
+    display: table;
+}
+.dropdown-menu.sortby li:nth-child(n+2){
+    display: table-row;
+}
+.dropdown-menu.sortby a{
+    display: table-cell;
+}
+.dropdown-menu.sortby a:nth-child(2n){
+    font-weight: bold;
+}

--- a/app/webroot/js/dashboard.js
+++ b/app/webroot/js/dashboard.js
@@ -1846,11 +1846,52 @@ function detChangepriority(caseId,priority,caseUniqId,cno) {
 	});
 }
 
+function ajaxMultiSorting(type){
+    if(typeof(getCookie("TASKSORT")!='undefined') && getCookie("TASKSORT") != '{}' && getCookie("TASKSORT") != '' ) {
+        var sort = JSON.parse( getCookie("TASKSORT") );
+        if( sort.hasOwnProperty( type ) )
+        {
+            if( sort[type] == 'ASC' )
+                sort[type] = 'DESC';
+            else
+                sort[type] = 'ASC';
+        }else{
+            sort[type] = 'ASC';
+        }
+
+    }else{
+        var sort= {};
+        sort[type] = 'ASC';
+    }
+    console.info( sort );
+    remember_filters( 'TASKSORT', JSON.stringify( sort ) );
+    easycase.refreshTaskList();
+}
+
 function ajaxSorting(type,cases,el){
 	/*if(typeof getCookie("TASKGROUPBY") !='undefined' && getCookie("TASKGROUPBY") !='date'){
 		return false;
-	} */ 
-	document.getElementById('isSort').value = "1";
+	} */
+    var newsort = {};
+    if(typeof(getCookie("TASKSORT")!='undefined') && getCookie("TASKSORT") != '{}' && getCookie("TASKSORT") != '' ) {
+        var sort = JSON.parse( getCookie("TASKSORT") );
+        if( sort.hasOwnProperty( type ) )
+        {
+            if( sort[type] == 'ASC' )
+                newsort[type] = 'DESC';
+            else
+                newsort[type] = 'ASC';
+        }else{
+            newsort[type] = 'ASC';
+        }
+
+    }else{
+        newsort[type] = 'ASC';
+    }
+    console.info( newsort );
+    remember_filters( 'TASKSORT', JSON.stringify( newsort ) );
+
+	/*document.getElementById('isSort').value = "1";
 	if(typeof(getCookie("TASKSORTBY")!='undefined') && getCookie("TASKSORTBY") ==type){
 		var tsorder = getCookie('TASKSORTORDER');
 		if(tsorder=='ASC'){
@@ -1865,8 +1906,8 @@ function ajaxSorting(type,cases,el){
 		remember_filters("TASKSORTORDER",'DESC');
 		var tcls = 'tsk_asc';
 	}
-	$('.tsk_sort').removeClass('tsk_asc tsk_desc'); 
-	var el= $('.sort'+type).children('.tsk_sort').addClass(tcls);
+	$('.tsk_sort').removeClass('tsk_asc tsk_desc');
+	var el= $('.sort'+type).children('.tsk_sort').addClass(tcls);*/
 	
 	/*if($(el).children('.tsk_sort.tsk_asc').length){
 		$('.tsk_sort').removeClass('tsk_asc tsk_desc');

--- a/app/webroot/js/dashboard.js
+++ b/app/webroot/js/dashboard.js
@@ -1863,15 +1863,11 @@ function ajaxMultiSorting(type){
         var sort= {};
         sort[type] = 'ASC';
     }
-    console.info( sort );
     remember_filters( 'TASKSORT', JSON.stringify( sort ) );
     easycase.refreshTaskList();
 }
 
 function ajaxSorting(type,cases,el){
-	/*if(typeof getCookie("TASKGROUPBY") !='undefined' && getCookie("TASKGROUPBY") !='date'){
-		return false;
-	} */
     var newsort = {};
     if(typeof(getCookie("TASKSORT")!='undefined') && getCookie("TASKSORT") != '{}' && getCookie("TASKSORT") != '' ) {
         var sort = JSON.parse( getCookie("TASKSORT") );
@@ -1888,7 +1884,6 @@ function ajaxSorting(type,cases,el){
     }else{
         newsort[type] = 'ASC';
     }
-    console.info( newsort );
     remember_filters( 'TASKSORT', JSON.stringify( newsort ) );
 
 	/*document.getElementById('isSort').value = "1";
@@ -1908,13 +1903,13 @@ function ajaxSorting(type,cases,el){
 	}
 	$('.tsk_sort').removeClass('tsk_asc tsk_desc');
 	var el= $('.sort'+type).children('.tsk_sort').addClass(tcls);*/
-	
+
 	/*if($(el).children('.tsk_sort.tsk_asc').length){
 		$('.tsk_sort').removeClass('tsk_asc tsk_desc');
 		$(el).children('.tsk_sort').addClass('tsk_desc');
-		
+
 		//$('#remember_filter').load(HTTP_ROOT+"easycases/remember_filters?issort=1&"+type+"=desc");
-		
+
 		$('#caseTitle, #caseDate, #caseDueDate, #caseNum, #caseLegendsort, #caseAtsort, #caseCreatedDate').val("");
 		if(type == "title"){
 			$('#caseTitle').val("desc");
@@ -1931,9 +1926,9 @@ function ajaxSorting(type,cases,el){
 	} else {
 		$('.tsk_sort').removeClass('tsk_asc tsk_desc');
 		$(el).children('.tsk_sort').addClass('tsk_asc');
-		
+
 		//$('#remember_filter').load(HTTP_ROOT+"easycases/remember_filters?issort=1&"+type+"=asc");
-		
+
 		$('#caseTitle, #caseDate, #caseDueDate, #caseNum, #caseLegendsort, #caseAtsort, #caseCreatedDate').val("");
 		if(type == "title"){
 			$('#caseTitle').val("asc");
@@ -2190,8 +2185,8 @@ function iniDueDateFilter(){
 		    $('#case_search, #caseSearch').val("");
 		    $('#case_srch').val("");
 		    var requiredUrl = document.URL;
-		    
-		    var n = requiredUrl.indexOf("filters=cases");	
+
+		    var n = requiredUrl.indexOf("filters=cases");
 		    if(n != -1){
 				remember_filters('CASESRCH','');
 				remember_filters('SEARCH','');
@@ -2207,8 +2202,7 @@ function iniDueDateFilter(){
 			casePage = 1;
 			//ajaxCaseView("case_project.php");
 		}else if(ftype=='taskorder'){
-			remember_filters('TASKSORTBY','');
-			remember_filters('TASKSORTORDER','');
+			remember_filters('TASKSORT','');
 		}else if(ftype=='taskgroupby'){
 			$('.sortby_btn').removeAttr('disabled');
 			$('.sortby_btn').removeClass('disable-btn');


### PR DESCRIPTION
I've added option Priority in "Sort by" menu, also now it's possible to sort items with by several options. This is achieved using the plus sign (+) in the Sortby menu. It works in following way, when you want to sort tasks by one option, you click the option name, and when you want to add another option for sorting, you click the + next to the option name. In that way you add another sorting condition.

This is a resolve for issue: Sort by Priority #91 