### PR TITLE
Update constants.php because of Gmail

### DIFF
--- a/app/Config/constants.php
+++ b/app/Config/constants.php
@@ -14,8 +14,8 @@ define("EMAIL_DELIVERY", "smtp");
 //Make sure to enable "php_openssl" in PHP. In WAMP, you need to enable extension=php_openssl.dll on php.ini file 
 
 //Gmail SMTP
-define("SMTP_HOST", "ssl://smtp.gmail.com");
-define("SMTP_PORT", "465");
+define("SMTP_HOST", "smtp.gmail.com");
+define("SMTP_PORT", "587");
 define("SMTP_UNAME", "youremail@gmail.com");
 define("SMTP_PWORD", "******");
 //https://www.arclab.com/en/amlc/list-of-smtp-and-imap-servers-mailserver-list.html (Get the list of Host names)


### PR DESCRIPTION
Gmail, and google in general, is no more accepting to send email if tls is off.
So we need to change this one for gmail, activating also the tls to true in lib/Cake/Network/Email/SmtpTransport.php
Otherwise no mail will be forwarded/delivered by the Gmail server