### PR TITLE
Move X-Frame-Options header to .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,6 @@
+<IfModule mod_headers.c>
+   Header append X-Frame-Options: DENY
+</IfModule>
 <IfModule mod_rewrite.c>
    RewriteEngine on
    RewriteRule    ^$ app/webroot/    [L]

--- a/app/View/Layouts/default_admin.ctp
+++ b/app/View/Layouts/default_admin.ctp
@@ -12,7 +12,6 @@ header("Pragma: no-cache");
 <!--[if (gt IE 9)|!(IE)]><!--> <html lang="en" class="no-js"> <!--<![endif]-->
 <head>
 <meta charset="UTF-8">
-<meta http-equiv="X-Frame-Options" content="deny">
 <?php echo $this->element('metadata'); ?>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <?php 

--- a/app/View/Layouts/default_inner.ctp
+++ b/app/View/Layouts/default_inner.ctp
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta http-equiv="X-Frame-Options" content="deny">
 <title>Orangescrum</title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="robots" content="noindex,nofollow" />

--- a/app/View/Layouts/default_outer.ctp
+++ b/app/View/Layouts/default_outer.ctp
@@ -1,7 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<meta http-equiv="X-Frame-Options" content="deny">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 <link rel="shortcut icon" href="<?php echo HTTP_ROOT; ?>favicon.ico"/>
 <meta name="robots" content="noindex,nofollow" />


### PR DESCRIPTION
X-Frame-Options is currently set via a meta tag, which in not the recommended way of doing so. By moving this to the root .htaccess, the header is set in the HTTP request as recommended.